### PR TITLE
Create separate mpjpe error function for training

### DIFF
--- a/fairmotion/tasks/motion_prediction/metrics.py
+++ b/fairmotion/tasks/motion_prediction/metrics.py
@@ -41,16 +41,3 @@ def euler_diff(predictions, targets):
 
     # reshape to original
     return np.reshape(euc_error, ori_shape)
-
-def mpjpe_error(predictions, targets):
-    assert predictions.shape[-1] == 3 and predictions.shape[-2] == 3
-    assert targets.shape[-1] == 3 and targets.shape[-2] == 3
-    n_joints = predictions.shape[-3]
-
-    ori_shape = predictions.shape[:-3]
-    preds = np.reshape(predictions, [-1, 3, 3])
-    targs = np.reshape(targets, [-1, 3, 3])
-
-    euler_preds = conversions.R2E(preds)  # (N, 3)
-    euler_targs = conversions.R2E(targs)  # (N, 3)
-    return torch.mean(torch.norm(euler_targs - euler_preds, 2, 1))

--- a/fairmotion/tasks/motion_prediction/test.py
+++ b/fairmotion/tasks/motion_prediction/test.py
@@ -100,11 +100,7 @@ def calculate_metrics(pred_seqs, tgt_seqs):
     metric_frames = [6, 12, 18, 24]
     R_pred, _ = conversions.T2Rp(pred_seqs)
     R_tgt, _ = conversions.T2Rp(tgt_seqs)
-    # euler_error = metrics.euler_diff(
-    #     R_pred[:, :, amass_dip.SMPL_MAJOR_JOINTS],
-    #     R_tgt[:, :, amass_dip.SMPL_MAJOR_JOINTS],
-    # )
-    euler_error = metrics.mpjpe_error(
+    euler_error = metrics.euler_diff(
         R_pred[:, :, amass_dip.SMPL_MAJOR_JOINTS],
         R_tgt[:, :, amass_dip.SMPL_MAJOR_JOINTS],
     )

--- a/fairmotion/tasks/motion_prediction/training.py
+++ b/fairmotion/tasks/motion_prediction/training.py
@@ -9,7 +9,7 @@ import random
 import torch
 import torch.nn as nn
 
-from fairmotion.tasks.motion_prediction import generate, utils, test, metrics
+from fairmotion.tasks.motion_prediction import generate, utils, test
 from fairmotion.utils import utils as fairmotion_utils
 
 
@@ -26,6 +26,11 @@ def set_seeds():
     random.seed(1)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
+
+def mpjpe_error(predictions, targets):
+    predictions = predictions.contiguous().view(-1, 3)
+    targets = targets.contiguous().view(-1, 3)
+    return torch.mean(torch.norm(targets - predictions, 2, 1))
 
 
 def train(args):
@@ -64,7 +69,7 @@ def train(args):
     )
 
     # criterion = nn.MSELoss()
-    criterion = metrics.mpjpe_error
+    criterion = mpjpe_error
     model.init_weights()
     training_losses, val_losses = [], []
 
@@ -73,8 +78,6 @@ def train(args):
         model.eval()
         src_seqs, tgt_seqs = src_seqs.to(device), tgt_seqs.to(device)
         outputs = model(src_seqs, tgt_seqs, teacher_forcing_ratio=1,)
-        # We might need to reshape this... The loss fn expects the shape:
-        # (..., n_joints, 3, 3)
         loss = criterion(outputs, tgt_seqs)
         epoch_loss += loss.item()
     epoch_loss = epoch_loss / num_training_sequences


### PR DESCRIPTION
- Revert the test metric to `euler_diff`. The end result is the same calculation used in STS-GCN's MPJPE algorithm: `mean(sqrt(sum((target - prediction)**2)))`
- Use a different implementation of MPJPE for training